### PR TITLE
Addresses the reconnect issue and 100% CPU consumption after disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ To run the receiver please use Python 3 and do the following:
 * Run the following commands
 
 ```zsh
+brew install python3
 brew install portaudio
-virtualenv proto
+virtualenv -p /usr/local/bin/python3 proto
 source proto/bin/activate
 pip install -r requirements.txt
 pip install --global-option=build_ext --global-option="-I/usr/local/Cellar/portaudio/19.6.0/include" --global-option="-L/usr/local/Cellar/portaudio/19.6.0/lib" pyaudio
 
 
-python ap2-receiver.py -m myap2
+python ap2-receiver.py -m myap2 --netiface=en0
 ```
 
 ## Windows

--- a/ap2-receiver.py
+++ b/ap2-receiver.py
@@ -441,6 +441,12 @@ class AP2Handler(http.server.BaseHTTPRequestHandler):
         self.send_header("Server", self.version_string())
         self.send_header("CSeq", self.headers["CSeq"])
         self.end_headers()
+        
+        # Erase the hap() instance, otherwise reconnects fail
+        self.server.hap = None
+
+        # terminate the forked event_proc, otherwise a zombie process consumes 100% cpu
+        self.event_proc.terminate()
 
     def do_SETPEERS(self):
         print("SETPEERS %s" % self.path)


### PR DESCRIPTION
Tested on macOS Catalina with iOS 14.4 client.

The client can now disconnect and reconnect.
Upon disconnecting, the `event_proc` is terminated - without which, the forked process goes to 100% CPU utilization (which happens witch each disconnect).